### PR TITLE
fix: send a User-Agent from the deploy healthcheck

### DIFF
--- a/scripts/healthcheck.ts
+++ b/scripts/healthcheck.ts
@@ -41,6 +41,14 @@ export interface HealthcheckOptions {
 
 const REQUEST_TIMEOUT_MS = 30000;
 
+/** Node's http/https modules send NO User-Agent by default — unlike fetch,
+ *  curl, or any browser. A request without one is blocked outright by common
+ *  WAF rulesets (AWSManagedRulesCommonRuleSet's NoUserAgent_HEADER returns
+ *  403), which made this healthcheck structurally incapable of ever returning
+ *  200 against the deploy target: it reported UNHEALTHY and rolled back two
+ *  perfectly good deploys before the cause was found. Identify ourselves. */
+export const USER_AGENT = "banana-split-deploy-healthcheck/1 (+https://github.com/mezinster/banana_split)";
+
 /** Redirects are deliberately NOT followed: the deploy target is a directory
  *  URL that must resolve to index.html at the edge, so a 301 here is a real
  *  finding about CloudFront configuration, not something to paper over. */
@@ -54,7 +62,11 @@ export function fetchPage(url: string): Promise<FetchedPage> {
         hostname: target.hostname,
         port: target.port,
         path: target.pathname + target.search,
-        headers: { "cache-control": "no-cache", pragma: "no-cache" }
+        headers: {
+          "cache-control": "no-cache",
+          pragma: "no-cache",
+          "user-agent": USER_AGENT
+        }
       },
       response => {
         let body = "";

--- a/tests/unit/healthcheck.spec.ts
+++ b/tests/unit/healthcheck.spec.ts
@@ -3,7 +3,7 @@
  */
 import * as http from "http";
 import { AddressInfo } from "net";
-import { checkOnce, healthcheck } from "../../scripts/healthcheck";
+import { checkOnce, healthcheck, USER_AGENT } from "../../scripts/healthcheck";
 
 interface StubResponse {
   status: number;
@@ -18,12 +18,15 @@ describe("healthcheck", () => {
   let responses: StubResponse[];
   let hits: number;
   let baseUrl: string;
+  let lastHeaders: http.IncomingHttpHeaders;
 
   beforeEach(async () => {
     hits = 0;
     responses = [];
+    lastHeaders = {};
     server = http.createServer((_req, res) => {
       // Serve each queued response once, then repeat the last one forever.
+      lastHeaders = _req.headers;
       const index = hits < responses.length ? hits : responses.length - 1;
       hits += 1;
       // eslint-disable-next-line security/detect-object-injection
@@ -53,6 +56,24 @@ describe("healthcheck", () => {
 
     expect(result.failures).toEqual([]);
     expect(result.ok).toBe(true);
+  });
+
+  it("identifies itself with a User-Agent on every request", async () => {
+    responses = [
+      {
+        status: 200,
+        contentType: "text/html; charset=utf-8",
+        body: "<html>build " + REVISION + "</html>"
+      }
+    ];
+
+    await checkOnce(baseUrl, REVISION);
+
+    // Node's http/https send no User-Agent by default, and WAF rulesets such as
+    // AWSManagedRulesCommonRuleSet reject that with a 403 — which once caused
+    // this healthcheck to roll back two good deploys.
+    expect(lastHeaders["user-agent"]).toBe(USER_AGENT);
+    expect(lastHeaders["cache-control"]).toBe("no-cache");
   });
 
   it("fails when the served page carries an older revision", async () => {


### PR DESCRIPTION
The deploy pipeline's healthcheck could never succeed against the live site, so it rolled back two deploys that had actually uploaded correctly.

## Cause

Node's `http`/`https` modules send **no** `User-Agent` header by default — unlike `fetch`, curl, or any browser. `fetchPage` passed an explicit `headers` object containing only `cache-control` and `pragma`, so requests went out with no UA.

The CloudFront distribution rejects those with a 403. Reproducible and not specific to this app:

```
curl -o /dev/null -w '%{http_code}'                  https://nfcarchiver.com/banana/   -> 200
curl -o /dev/null -w '%{http_code}' -H 'User-Agent;' https://nfcarchiver.com/banana/   -> 403
curl -o /dev/null -w '%{http_code}' -H 'User-Agent;' https://nfcarchiver.com/app/      -> 403
```

That is the signature of WAF's `AWSManagedRulesCommonRuleSet` → `NoUserAgent_HEADER`.

## Effect

Runs 30700587100 and 30700805590 both uploaded successfully, then failed verification with `403 (want 200)` on all six attempts and reverted. Nothing was ever wrong with the deploys — the rollback path worked correctly on evidence that was itself wrong.

## Fix

Send an identifying `User-Agent`. Adds a test that captures the headers the stub server actually receives; verified by mutation — removing the header fails that test and no other.

Local check against the real site with the compiled CLI:

```
healthy: https://nfcarchiver.com/banana/ is serving build v0.8.3-0-g6b3bf07
exit=0
```

36 tests pass; lint clean in both scopes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)