### PR TITLE
chore: record the 0.8.5 F-Droid build in the local metadata copy

### DIFF
--- a/fdroid/com.nfcarchiver.banana_split.yml
+++ b/fdroid/com.nfcarchiver.banana_split.yml
@@ -68,8 +68,37 @@ Builds:
       - $$flutter$$/bin/flutter gen-l10n
       - $$flutter$$/bin/flutter build apk --release
 
+  - versionName: 0.8.5
+    versionCode: 4
+    commit: df7464f3a88d900745367f47865e9bc90f5b541c
+    subdir: banana_split_flutter
+    sudo:
+      - echo "deb https://deb.debian.org/debian bookworm main" > /etc/apt/sources.list.d/bookworm.list
+      - apt-get update
+      - apt-get install -y -t bookworm openjdk-17-jdk-headless
+      - update-java-alternatives -s java-1.17.0-openjdk-amd64
+    output: build/app/outputs/flutter-apk/app-release.apk
+    srclibs:
+      - flutter@stable
+    prebuild:
+      - flutterVersion=$(sed -n -E "s/.*FLUTTER_VERSION:\ '(.*)'/\1/p" ../.github/workflows/release.yml)
+      - '[[ $flutterVersion ]]'
+      - git -C $$flutter$$ checkout -f $flutterVersion
+      - export PUB_CACHE=$(pwd)/.pub-cache
+      - $$flutter$$/bin/flutter config --no-analytics
+      - sed -i '/mobile_scanner:/d' pubspec.yaml
+      - cp lib/widgets/shard_scanner.dart.fdroid lib/widgets/shard_scanner.dart
+      - $$flutter$$/bin/flutter pub get
+    scandelete:
+      - banana_split_flutter/.pub-cache
+    build:
+      - export JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64
+      - export PUB_CACHE=$(pwd)/.pub-cache
+      - $$flutter$$/bin/flutter gen-l10n
+      - $$flutter$$/bin/flutter build apk --release
+
 AutoUpdateMode: Version
 UpdateCheckMode: Tags
 UpdateCheckData: banana_split_flutter/pubspec.yaml|version:\s.+\+(\d+)|.|version:\s(.+)\+
-CurrentVersion: 0.8.3
-CurrentVersionCode: 3
+CurrentVersion: 0.8.5
+CurrentVersionCode: 4


### PR DESCRIPTION
Follow-up to #3. Records the v0.8.5 release in the local F-Droid metadata mirror.

- Adds the `versionCode: 4` build entry pinned to `df7464f` (the v0.8.5 merge commit)
- Moves `CurrentVersion`/`CurrentVersionCode` to `0.8.5`/`4`

### Why this was needed

`v0.8.4` was tagged against the unmerged Spanish branch and `pubspec.yaml` was never bumped — it stayed at `0.8.3+3`. F-Droid's `UpdateCheckData` parses the **committed** pubspec, so it still saw versionCode 3 and would never have offered the update. The GitHub release workflow rewrites pubspec at build time from `git rev-list --count HEAD`, which is why the v0.8.4 artifacts looked correctly versioned (`0.8.4+364`) and masked the problem.

`v0.8.5` carries `0.8.5+4` in the committed pubspec, so F-Droid can detect it.

### Still needed outside this repo

The canonical metadata lives in `fdroiddata` at `metadata/com.nfcarchiver.banana_split.yml` (fork: `gitlab.com/mezinster/fdroiddata`). The same build entry and commit hash must be set there via an update MR — this repo's copy is a mirror only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)