### PR TITLE
fix: pin the Windows build runner to windows-2022

### DIFF
--- a/.github/workflows/flutter-ci.yml
+++ b/.github/workflows/flutter-ci.yml
@@ -90,7 +90,9 @@ jobs:
     name: Build Windows
     needs: analyze-and-test
     if: github.event_name == 'workflow_dispatch' && inputs.build_windows
-    runs-on: windows-latest
+    # Pinned for the same reason as release.yml's build-windows job: Flutter
+    # 3.24.5 cannot detect Visual Studio on the current windows-latest image.
+    runs-on: windows-2022
     defaults:
       run:
         working-directory: banana_split_flutter

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -214,7 +214,14 @@ jobs:
   build-windows:
     name: Build Windows
     needs: [version, test]
-    runs-on: windows-latest
+    # Pinned, not windows-latest. Flutter 3.24.5 locates Visual Studio with a
+    # vswhere query that finds nothing on the image windows-latest now points
+    # at; it then falls back to the "Visual Studio 16 2019" CMake generator and
+    # fails with "could not find any instance of Visual Studio". v0.8.4 built
+    # here fine on 2026-05-26, so this is runner-image drift, not a code change.
+    # Unpin only together with a FLUTTER_VERSION bump — and note F-Droid greps
+    # FLUTTER_VERSION out of this file, so that bump reaches the F-Droid build.
+    runs-on: windows-2022
     defaults:
       run:
         working-directory: banana_split_flutter


### PR DESCRIPTION
The v0.8.5 release failed in `build-windows`:

```
CMake Error at CMakeLists.txt:3 (project):
  Generator "Visual Studio 16 2019" could not find any instance of Visual Studio.
```

### Root cause: runner-image drift, not a code change

Flutter 3.24.5 locates Visual Studio via a `vswhere` query. That query finds nothing on the image `windows-latest` now resolves to, so Flutter falls back to the `Visual Studio 16 2019` CMake generator — which then finds no VS 2019 either.

The evidence that this is drift: **v0.8.4 built Windows successfully on 2026-05-26** with this exact `runs-on: windows-latest` and the same `FLUTTER_VERSION: 3.24.5`. Nothing between then and now touched the Windows build.

### Why pin rather than bump Flutter

Pinning to `windows-2022` restores a known-good pairing and touches one line per workflow.

Bumping `FLUTTER_VERSION` would also fix it but has a wider blast radius: F-Droid's prebuild greps `FLUTTER_VERSION` out of `release.yml`, so the bump would silently change the F-Droid build's toolchain too. That deserves its own change with its own verification, not a hotfix to unblock a release.

Applied to both `release.yml` (which blocks the GitHub Release — it `needs` all three build jobs) and `flutter-ci.yml`'s on-demand Windows build.

### Follow-up

`windows-2022` will itself be deprecated eventually. The durable fix is a Flutter bump, validated against the F-Droid build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)