### PR TITLE
ci: scope checks per changed area and validate store metadata

### DIFF
--- a/.github/workflows/deploy-webapp.yml
+++ b/.github/workflows/deploy-webapp.yml
@@ -136,7 +136,7 @@ jobs:
         run: |
           set -euo pipefail
           npx tsc scripts/healthcheck.ts scripts/healthcheck-cli.ts \
-            --outDir tools --module commonjs --target es2019 \
+            --outDir healthcheck-dist --module commonjs --target es2019 \
             --strict --esModuleInterop --skipLibCheck
 
       - name: Verify the compiled healthcheck starts
@@ -154,7 +154,7 @@ jobs:
         run: |
           set -uo pipefail
           code=0
-          node tools/healthcheck-cli.js >/dev/null 2>&1 || code=$?
+          node healthcheck-dist/healthcheck-cli.js >/dev/null 2>&1 || code=$?
           if [ "$code" -ne 2 ]; then
             echo "::error::compiled healthcheck did not start correctly (exit ${code}, want 2)"
             exit 1
@@ -175,7 +175,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: deploy-tools
-          path: tools/
+          path: healthcheck-dist/
           if-no-files-found: error
           retention-days: 7
 
@@ -206,7 +206,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: deploy-tools
-          path: tools
+          path: healthcheck-dist
 
       - name: Setup Node
         uses: actions/setup-node@v4
@@ -328,9 +328,9 @@ jobs:
           set -euo pipefail
           if [ "${FORCE_FAIL}" = "true" ]; then
             echo "::warning::force_fail_verify is set — using a revision that cannot match, to exercise rollback"
-            node tools/healthcheck-cli.js "${BASE_URL}" "force-fail-verify-no-such-revision"
+            node healthcheck-dist/healthcheck-cli.js "${BASE_URL}" "force-fail-verify-no-such-revision"
           else
-            node tools/healthcheck-cli.js "${BASE_URL}" "${REVISION}"
+            node healthcheck-dist/healthcheck-cli.js "${BASE_URL}" "${REVISION}"
           fi
         env:
           FORCE_FAIL: ${{ inputs.force_fail_verify }}

--- a/.github/workflows/flutter-ci.yml
+++ b/.github/workflows/flutter-ci.yml
@@ -1,16 +1,12 @@
 name: Flutter CI
 
+# Scoping is done per job via the `changes` job, not with a workflow-level
+# `paths:` filter — see the comment in web-ci.yml for why.
 on:
   push:
     branches: [main, master, develop]
-    paths:
-      - 'banana_split_flutter/**'
-      - '.github/workflows/flutter-ci.yml'
   pull_request:
     branches: [main, master, develop]
-    paths:
-      - 'banana_split_flutter/**'
-      - '.github/workflows/flutter-ci.yml'
   workflow_dispatch:
     inputs:
       build_debug_apk:
@@ -25,9 +21,80 @@ on:
         default: true
 
 jobs:
+  changes:
+    name: Detect changed areas
+    runs-on: ubuntu-latest
+    outputs:
+      flutter: ${{ steps.filter.outputs.flutter }}
+      metadata: ${{ steps.filter.outputs.metadata }}
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Classify changed paths
+        id: filter
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+        run: |
+          set -euo pipefail
+
+          # Fail open on branch creation, a force-pushed base, or a manual
+          # dispatch: run everything rather than risk skipping.
+          if [ -z "$BASE_SHA" ] || ! git cat-file -e "${BASE_SHA}^{commit}" 2>/dev/null; then
+            echo "Base commit unavailable ($BASE_SHA) — running all jobs."
+            echo "flutter=true" >> "$GITHUB_OUTPUT"
+            echo "metadata=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          files=$(git diff --name-only "${BASE_SHA}...${HEAD_SHA}")
+          echo "Changed files:"
+          echo "$files" | sed 's/^/  /'
+
+          flutter=false
+          metadata=false
+
+          if grep -qE '^banana_split_flutter/|^\.github/workflows/flutter-ci\.yml$' <<< "$files"; then
+            flutter=true
+          fi
+
+          # Store metadata, the F-Droid recipe, the validator itself, and
+          # pubspec.yaml — which supplies the versionCode the changelog files
+          # are named after, and which F-Droid reads to detect new releases.
+          if grep -qE '^(fastlane|fdroid|tools)/|^banana_split_flutter/pubspec\.yaml$|^banana_split_flutter/lib/l10n/|^\.github/workflows/flutter-ci\.yml$' <<< "$files"; then
+            metadata=true
+          fi
+
+          echo "flutter=$flutter" >> "$GITHUB_OUTPUT"
+          echo "metadata=$metadata" >> "$GITHUB_OUTPUT"
+          echo "flutter=\`$flutter\` metadata=\`$metadata\`" >> "$GITHUB_STEP_SUMMARY"
+
+  validate-metadata:
+    name: Validate Store Metadata
+    runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.metadata == 'true'
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install PyYAML
+        run: pip install --quiet pyyaml
+
+      - name: Validate F-Droid recipe and fastlane listings
+        run: python3 tools/validate_store_metadata.py
+
   analyze-and-test:
     name: Analyze & Test
     runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.flutter == 'true'
     defaults:
       run:
         working-directory: banana_split_flutter

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,6 +68,32 @@ jobs:
           echo "Build Number: ${BUILD_NUMBER}"
           echo "Branch: ${BRANCH}"
 
+      # The build jobs below rewrite pubspec.yaml from VERSION+BUILD_NUMBER, so
+      # the artifacts are correctly versioned no matter what is committed. That
+      # is exactly what made this failure invisible for v0.8.4: the release
+      # shipped as 0.8.4+364 while the committed pubspec still read 0.8.3+3.
+      # F-Droid's UpdateCheckData parses the *committed* pubspec, so it never
+      # saw a new versionCode and could not offer the update to anyone.
+      - name: Refuse to release a version the committed pubspec disagrees with
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          set -euo pipefail
+          pubspec_version="$(sed -n -E 's/^version:[[:space:]]*([^+]+)\+([0-9]+)[[:space:]]*$/\1/p' banana_split_flutter/pubspec.yaml)"
+          pubspec_code="$(sed -n -E 's/^version:[[:space:]]*([^+]+)\+([0-9]+)[[:space:]]*$/\2/p' banana_split_flutter/pubspec.yaml)"
+
+          if [ -z "$pubspec_version" ] || [ -z "$pubspec_code" ]; then
+            echo "::error::banana_split_flutter/pubspec.yaml has no 'version: <name>+<code>' line"
+            exit 1
+          fi
+
+          echo "committed pubspec: ${pubspec_version}+${pubspec_code} | releasing: ${VERSION}"
+
+          if [ "$pubspec_version" != "$VERSION" ]; then
+            echo "::error::Releasing ${VERSION} but the committed pubspec.yaml says ${pubspec_version}+${pubspec_code}. F-Droid reads the committed pubspec to detect releases, so it would never offer this build. Bump banana_split_flutter/pubspec.yaml (version AND the +versionCode) and commit before releasing."
+            exit 1
+          fi
+
   test:
     name: Run Tests
     runs-on: ubuntu-latest

--- a/.github/workflows/web-ci.yml
+++ b/.github/workflows/web-ci.yml
@@ -1,23 +1,73 @@
 name: Web App CI
 
+# No workflow-level `paths:` / `paths-ignore:` filter, deliberately. A workflow
+# filtered out that way never reports its checks at all, so the moment any of
+# these jobs becomes a required status check, every Flutter-only PR would sit
+# forever on "Expected — waiting for status". A job skipped by `if:` still posts
+# its check run with conclusion "skipped", which rulesets accept. Scoping is
+# therefore done per job, against the `changes` job below.
 on:
   push:
     branches: [master]
-    paths-ignore:
-      - 'banana_split_flutter/**'
-      - '.github/workflows/flutter-*'
   pull_request:
     branches: [master]
-    paths-ignore:
-      - 'banana_split_flutter/**'
-      - '.github/workflows/flutter-*'
   schedule:
     - cron: '30 23 * * 5'
 
 jobs:
+  changes:
+    name: Detect changed areas
+    runs-on: ubuntu-latest
+    outputs:
+      webapp: ${{ steps.filter.outputs.webapp }}
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # Full history so the base commit of the diff is present locally.
+          fetch-depth: 0
+
+      - name: Classify changed paths
+        id: filter
+        env:
+          # Interpolated into the environment, not into the script body.
+          BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+        run: |
+          set -euo pipefail
+
+          # Branch creation, a force-pushed base, or a scheduled run means we
+          # cannot tell what changed. Fail open and run everything — a wasted
+          # run costs minutes, a wrongly skipped one ships untested code.
+          if [ -z "$BASE_SHA" ] || ! git cat-file -e "${BASE_SHA}^{commit}" 2>/dev/null; then
+            echo "Base commit unavailable ($BASE_SHA) — running all jobs."
+            echo "webapp=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # Three-dot: diff against the merge base, so commits that landed on
+          # master after this PR opened are not counted as our changes.
+          files=$(git diff --name-only "${BASE_SHA}...${HEAD_SHA}")
+          echo "Changed files:"
+          echo "$files" | sed 's/^/  /'
+
+          webapp=false
+
+          # This workflow appears in the set: a change to the pipeline must be
+          # validated by every job the pipeline runs. deploy-webapp.yml builds
+          # and healthchecks the same bundle, and compiles scripts/healthcheck*.
+          if grep -qE '^(src|public|tests|scripts)/|^(package\.json|yarn\.lock|vue\.config\.js|jest\.config\.js|tsconfig\.json|playwright\.config\.ts|\.babelrc|\.eslintrc\.js|\.nvmrc)$|^\.github/workflows/(web-ci|deploy-webapp)\.yml$' <<< "$files"; then
+            webapp=true
+          fi
+
+          echo "webapp=$webapp" >> "$GITHUB_OUTPUT"
+          echo "webapp=\`$webapp\`" >> "$GITHUB_STEP_SUMMARY"
+
   lint-and-test:
     name: Lint & Unit Tests
     runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.webapp == 'true'
     steps:
       - uses: actions/checkout@v4
         with:
@@ -43,7 +93,8 @@ jobs:
 
   e2e-test:
     name: E2E Tests
-    needs: lint-and-test
+    needs: [changes, lint-and-test]
+    if: needs.changes.outputs.webapp == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -74,6 +125,8 @@ jobs:
   codeql:
     name: CodeQL Analysis
     runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.webapp == 'true'
     permissions:
       actions: read
       contents: read
@@ -93,6 +146,8 @@ jobs:
   trivy:
     name: Trivy Vulnerability Scan
     runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.webapp == 'true'
     permissions:
       actions: read
       contents: read

--- a/.gitignore
+++ b/.gitignore
@@ -4,13 +4,14 @@ node_modules
 
 # Deploy pipeline staging directories, both build output of
 # .github/workflows/deploy-webapp.yml:
-#   /site   — the single dist/index.html staged for upload
-#   /tools  — the compiled healthcheck (tsc output of scripts/healthcheck*.ts)
-# `/tools` is a generic name. If a real, source-controlled tools/ directory is
-# ever added to this repo it would be silently ignored by this line — change
-# the compiler's --outDir instead of deleting the rule.
+#   /site             — the single dist/index.html staged for upload
+#   /healthcheck-dist — compiled healthcheck (tsc output of scripts/healthcheck*.ts)
+# This was `/tools`, whose generic name would have silently ignored the real,
+# source-controlled tools/ directory that now holds the store-metadata
+# validator. Per the note that used to live here, the compiler's --outDir was
+# repointed rather than the rule deleted. Keep this name specific.
 /site
-/tools
+/healthcheck-dist
 
 # local env files
 .env.local

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -112,9 +112,40 @@ Flutter port of Banana Split targeting Android and desktop (Windows/macOS/Linux)
 
 ### CI/CD
 
-- **Flutter CI** (`.github/workflows/flutter-ci.yml`): Analyze + test on push/PR (scoped to `banana_split_flutter/`). On-demand debug APK and release Windows builds via `workflow_dispatch`.
+- **Flutter CI** (`.github/workflows/flutter-ci.yml`): Analyze + test, plus store-metadata validation. On-demand debug APK and release Windows builds via `workflow_dispatch`.
 - **Release** (`.github/workflows/release.yml`): Triggered by tag push (`v*.*.*`) or manual dispatch. Builds Android (APK + AAB), Windows (zip), and Web (single HTML file) in parallel. Creates GitHub Release with all artifacts and checksums.
-- **Web App CI** (`.github/workflows/web-ci.yml`): Lint, unit tests, E2E tests, CodeQL, Trivy scan. Skips Flutter-only changes via `paths-ignore`.
+- **Web App CI** (`.github/workflows/web-ci.yml`): Lint, unit tests, E2E tests, CodeQL, Trivy scan.
+
+**Path scoping.** Both CI workflows run on every push/PR and scope themselves
+per job with `if: needs.changes.outputs.<area> == 'true'`, never with a
+workflow-level `paths:` / `paths-ignore:` filter. This is deliberate: a workflow
+excluded by `paths:` never reports its checks at all, so any job that is a
+required status check would leave unrelated PRs stuck on "Expected — waiting for
+status" forever. A job skipped by `if:` still posts a check run with conclusion
+`skipped`, which rulesets accept. The `changes` job diffs three-dot against the
+merge base and **fails open** — an unavailable base commit (branch creation,
+force-push, scheduled run, manual dispatch) runs everything. Changing a
+classifier regex is a correctness change: it can silently stop testing an area.
+
+The Windows build runners are pinned to `windows-2022`. Flutter 3.24.5 cannot
+detect Visual Studio on the image `windows-latest` now resolves to and falls
+back to the VS 2019 CMake generator. Unpin only alongside a `FLUTTER_VERSION`
+bump — and note F-Droid greps `FLUTTER_VERSION` out of `release.yml`, so that
+bump reaches the F-Droid build too.
+
+`release.yml` refuses to release a version the committed `pubspec.yaml`
+disagrees with. The build jobs rewrite pubspec from the tag, so artifacts are
+always correctly versioned — which is exactly what hid the v0.8.4 failure, where
+the release shipped as `0.8.4+364` while the committed pubspec still read
+`0.8.3+3` and F-Droid, which parses the committed file, never saw the update.
+
+**Store metadata** (`tools/validate_store_metadata.py`, run by Flutter CI on
+`fastlane/`, `fdroid/`, `tools/`, `pubspec.yaml`, and `lib/l10n/` changes):
+checks the F-Droid recipe parses and pins full 40-char commits, that every
+fastlane locale has title/short/full description, that a changelog exists for
+the current `versionCode` in every locale and fits F-Droid's 500-char limit, and
+that **every `app_<locale>.arb` has a matching store listing** — the check that
+catches shipping a language with no store page. Run it locally the same way.
 
 ### F-Droid
 

--- a/tools/validate_store_metadata.py
+++ b/tools/validate_store_metadata.py
@@ -1,0 +1,209 @@
+#!/usr/bin/env python3
+"""Validate the F-Droid metadata and the fastlane store listings.
+
+Neither CI workflow used to look at fastlane/ or fdroid/, which is how the
+0.8.5 release managed to go out with an unbumped versionCode and no changelogs.
+Run locally with:
+
+    python3 tools/validate_store_metadata.py
+
+Exits non-zero and prints every problem it found, rather than stopping at the
+first one — a release checklist is more useful complete than early.
+"""
+
+import os
+import re
+import sys
+
+import yaml
+
+REPO = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+PUBSPEC = os.path.join(REPO, "banana_split_flutter", "pubspec.yaml")
+FDROID = os.path.join(REPO, "fdroid", "com.nfcarchiver.banana_split.yml")
+LISTINGS = os.path.join(REPO, "fastlane", "metadata", "android")
+ARB_DIR = os.path.join(REPO, "banana_split_flutter", "lib", "l10n")
+
+# F-Droid renders changelogs in a fixed-width column and truncates past this.
+CHANGELOG_MAX_CHARS = 500
+REQUIRED_LISTING_FILES = ("title.txt", "short_description.txt", "full_description.txt")
+
+problems = []
+
+
+def fail(msg):
+    problems.append(msg)
+
+
+def read_pubspec_version():
+    """Return (versionName, versionCode) from the committed pubspec."""
+    with open(PUBSPEC, encoding="utf-8") as fh:
+        for line in fh:
+            m = re.match(r"^version:\s*(\S+)\+(\d+)\s*$", line)
+            if m:
+                return m.group(1), int(m.group(2))
+    fail("pubspec.yaml has no 'version: <name>+<code>' line")
+    return None, None
+
+
+def check_fdroid(version_name, version_code):
+    with open(FDROID, encoding="utf-8") as fh:
+        meta = yaml.safe_load(fh)
+
+    builds = meta.get("Builds") or []
+    if not builds:
+        fail("fdroid metadata has no Builds entries")
+        return
+
+    codes = [b.get("versionCode") for b in builds]
+    dupes = {c for c in codes if codes.count(c) > 1}
+    if dupes:
+        fail("fdroid metadata has duplicate versionCode(s): %s" % sorted(dupes))
+
+    for b in builds:
+        for key in ("versionName", "versionCode", "commit", "subdir"):
+            if not b.get(key):
+                fail("fdroid build %s is missing '%s'" % (b.get("versionName", "?"), key))
+        commit = str(b.get("commit", ""))
+        if commit and not re.fullmatch(r"[0-9a-f]{40}", commit):
+            fail(
+                "fdroid build %s pins commit '%s' — expected a full 40-char sha"
+                % (b.get("versionName"), commit)
+            )
+
+    cur_code = meta.get("CurrentVersionCode")
+    cur_name = str(meta.get("CurrentVersion"))
+
+    # F-Droid's UpdateCheckData reads the versionCode out of the committed
+    # pubspec. If CurrentVersionCode runs ahead of it, F-Droid believes it has
+    # already shipped a build that does not exist in the tree.
+    if cur_code is not None and version_code is not None and cur_code > version_code:
+        fail(
+            "fdroid CurrentVersionCode (%s) is ahead of pubspec versionCode (%s)"
+            % (cur_code, version_code)
+        )
+
+    if cur_code is not None and cur_code not in codes:
+        fail(
+            "fdroid CurrentVersionCode (%s) has no matching build entry (have %s)"
+            % (cur_code, sorted(c for c in codes if c is not None))
+        )
+
+    if cur_code is not None and cur_name:
+        match = [b for b in builds if b.get("versionCode") == cur_code]
+        if match and str(match[0].get("versionName")) != cur_name:
+            fail(
+                "fdroid CurrentVersion '%s' disagrees with the versionCode %s build entry ('%s')"
+                % (cur_name, cur_code, match[0].get("versionName"))
+            )
+
+
+def check_listings(version_code):
+    if not os.path.isdir(LISTINGS):
+        fail("missing fastlane listings directory: %s" % LISTINGS)
+        return
+
+    locales = sorted(
+        d for d in os.listdir(LISTINGS) if os.path.isdir(os.path.join(LISTINGS, d))
+    )
+    if not locales:
+        fail("no locale directories under %s" % LISTINGS)
+        return
+
+    for loc in locales:
+        base = os.path.join(LISTINGS, loc)
+
+        for name in REQUIRED_LISTING_FILES:
+            path = os.path.join(base, name)
+            if not os.path.isfile(path):
+                fail("%s: missing %s" % (loc, name))
+                continue
+            with open(path, encoding="utf-8") as fh:
+                if not fh.read().strip():
+                    fail("%s: %s is empty" % (loc, name))
+
+        if version_code is None:
+            continue
+
+        changelog = os.path.join(base, "changelogs", "%d.txt" % version_code)
+        if not os.path.isfile(changelog):
+            fail(
+                "%s: no changelog for versionCode %d (expected changelogs/%d.txt)"
+                % (loc, version_code, version_code)
+            )
+            continue
+
+        with open(changelog, encoding="utf-8") as fh:
+            text = fh.read()
+        if not text.strip():
+            fail("%s: changelogs/%d.txt is empty" % (loc, version_code))
+        elif len(text) > CHANGELOG_MAX_CHARS:
+            fail(
+                "%s: changelogs/%d.txt is %d chars, over F-Droid's %d limit"
+                % (loc, version_code, len(text), CHANGELOG_MAX_CHARS)
+            )
+
+    return locales
+
+
+def check_app_locales_have_listings(store_locales):
+    """Every language the app ships in needs a store listing.
+
+    This is the check that would have caught the Spanish release: app_es.arb
+    was added and the app shipped in Spanish, but fastlane had no es-ES
+    directory, so Spanish users saw an English store page. Iterating the
+    listing directories alone cannot catch a listing that was never created.
+    """
+    if not os.path.isdir(ARB_DIR):
+        fail("missing ARB directory: %s" % ARB_DIR)
+        return
+
+    app_locales = set()
+    for name in os.listdir(ARB_DIR):
+        m = re.fullmatch(r"app_([A-Za-z]{2,3})\.arb", name)
+        if m:
+            app_locales.add(m.group(1).lower())
+
+    if not app_locales:
+        fail("no app_<locale>.arb files found in %s" % ARB_DIR)
+        return
+
+    # Store dirs are region-qualified (es-ES, ka-GE) or bare (uk); compare on
+    # the language subtag only.
+    store_languages = {loc.split("-")[0].lower() for loc in store_locales}
+
+    for lang in sorted(app_locales - store_languages):
+        fail(
+            "app ships locale '%s' (app_%s.arb) but no fastlane store listing exists for it"
+            % (lang, lang)
+        )
+
+    for lang in sorted(store_languages - app_locales):
+        fail(
+            "fastlane has a store listing for '%s' but the app has no app_%s.arb"
+            % (lang, lang)
+        )
+
+    print("app locales: %s" % ", ".join(sorted(app_locales)))
+
+
+def main():
+    version_name, version_code = read_pubspec_version()
+    print("pubspec version: %s+%s" % (version_name, version_code))
+
+    check_fdroid(version_name, version_code)
+    locales = check_listings(version_code) or []
+    print("store locales checked: %s" % ", ".join(locales))
+    check_app_locales_have_listings(locales)
+
+    if problems:
+        print("\n%d problem(s):" % len(problems), file=sys.stderr)
+        for p in problems:
+            print("  - %s" % p, file=sys.stderr)
+        return 1
+
+    print("\nstore metadata OK")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Speeds up PR checks by running only the jobs a change can actually affect, and closes the validation gap that let today's release bugs through.

## The problem

`web-ci.yml` scoped itself with `paths-ignore`, a **denylist** — so every path added to the repo since it was written defaulted to running the full web suite. Two PRs from today:

| PR | Changed | Ran |
|---|---|---|
| #6 | `fdroid/*.yml` (1 file) | lint, unit, E2E, CodeQL, Trivy |
| #7 | 2 workflow YAMLs | lint, unit, E2E, CodeQL, Trivy |

Meanwhile `fastlane/` and `fdroid/` were validated by **neither** workflow — which is precisely where the bugs lived.

## Approach: job-level `if:`, not workflow-level `paths:`

Follows the convention already in the nfcarchiver repo. A workflow excluded by `paths:` never reports its checks at all, so any job that is a required status check would leave unrelated PRs stuck on *"Expected — waiting for status"* forever. A job skipped by `if:` still posts a check run with conclusion `skipped`, which rulesets accept.

The `changes` detector diffs **three-dot** against the merge base (so commits landing on master after the PR opened aren't miscounted) and **fails open** — an unavailable base commit (branch creation, force-push, scheduled run, manual dispatch) runs everything. A wasted run costs minutes; a wrongly skipped one ships untested code.

Verified against 14 cases including the three real PRs from today:

```
PASS  PR#3 Spanish (web+flutter+meta)    web=true  flutter=true  meta=true
PASS  PR#6 fdroid yaml only              web=false flutter=false meta=true
PASS  PR#7 release+flutter-ci yaml       web=false flutter=true  meta=true
PASS  web code only / deps / healthcheck / deploy workflow
PASS  flutter code only / ARB locale
PASS  fastlane changelog / validator tool
PASS  docs only / LICENSE only           (all false)
```

The "both" case needs no special handling — it falls out for free.

## New: store metadata validation

`tools/validate_store_metadata.py`, run by Flutter CI on `fastlane/`, `fdroid/`, `tools/`, `pubspec.yaml` and `lib/l10n/` changes. Checks:

- the F-Droid recipe parses, has no duplicate versionCodes, pins full 40-char commits
- `CurrentVersionCode` is not ahead of pubspec and has a matching build entry
- every fastlane locale has title / short / full description, non-empty
- a changelog exists for the current versionCode in every locale, within F-Droid's 500-char limit
- **every `app_<locale>.arb` has a matching store listing**

Both real bugs replayed against it:

```
BUG 1: app ships Spanish, no es-ES listing
  - app ships locale 'es' (app_es.arb) but no fastlane store listing exists for it

BUG 2: versionCode bumped, changelogs never written
  - be-BY: no changelog for versionCode 5 (expected changelogs/5.txt)   [x8 locales]
```

## Also

- `release.yml` now refuses a version the committed `pubspec.yaml` disagrees with — the failure that let v0.8.4 ship as `0.8.4+364` while the committed pubspec read `0.8.3+3`, leaving F-Droid unable to see the release.
- `.gitignore` ignored `/tools` as the healthcheck's tsc `--outDir`, with a note warning this would silently swallow a real `tools/` directory and that the fix was to repoint the compiler. That is exactly what happened, so `--outDir` moved to `healthcheck-dist`. Not dot-prefixed: `upload-artifact@v4` omits hidden files by default and would have broken the healthcheck upload quietly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)