### PR TITLE
chore: pin the F-Droid 0.8.5 build to the released tag commit

### DIFF
--- a/fdroid/com.nfcarchiver.banana_split.yml
+++ b/fdroid/com.nfcarchiver.banana_split.yml
@@ -70,7 +70,7 @@ Builds:
 
   - versionName: 0.8.5
     versionCode: 4
-    commit: df7464f3a88d900745367f47865e9bc90f5b541c
+    commit: ee9308a556bc5201364fb5d6dbc48894147bcaf6
     subdir: banana_split_flutter
     sudo:
       - echo "deb https://deb.debian.org/debian bookworm main" > /etc/apt/sources.list.d/bookworm.list


### PR DESCRIPTION
PR #6 pinned `df7464f` — the commit `v0.8.5` pointed at when it was written. The release was then rebuilt from master to pick up the Windows runner fix (#7), which force-moved the tag to `ee9308a`, leaving the F-Droid build pinned to a commit corresponding to no tag.

Both commits carry `pubspec: 0.8.5+4` and identical Android sources, so build output is unaffected. This is for auditability — the F-Droid recipe should name the commit the release was actually cut from, since that hash also goes into the `fdroiddata` update MR.

### Doubles as a live test of #8

This PR touches exactly one file, `fdroid/com.nfcarchiver.banana_split.yml`. Before #8 it would have run lint, unit tests, Playwright E2E, CodeQL and Trivy. It should now run **only** `Validate Store Metadata`, with the web and Flutter jobs reported as skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)