### PR TITLE
chore: record the 0.8.6 F-Droid build and reconcile with canonical

### DIFF
--- a/fdroid/com.nfcarchiver.banana_split.yml
+++ b/fdroid/com.nfcarchiver.banana_split.yml
@@ -25,6 +25,8 @@ Builds:
     srclibs:
       - flutter@stable
     prebuild:
+      - sed -i -e '/mobile_scanner/d' pubspec.yaml
+      - mv lib/widgets/shard_scanner.dart.fdroid lib/widgets/shard_scanner.dart
       - flutterVersion=$(sed -n -E "s/.*FLUTTER_VERSION:\ '(.*)'/\1/p" ../.github/workflows/release.yml)
       - '[[ $flutterVersion ]]'
       - git -C $$flutter$$ checkout -f $flutterVersion
@@ -34,14 +36,13 @@ Builds:
     scandelete:
       - banana_split_flutter/.pub-cache
     build:
-      - export JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64
       - export PUB_CACHE=$(pwd)/.pub-cache
       - $$flutter$$/bin/flutter gen-l10n
       - $$flutter$$/bin/flutter build apk --release
 
   - versionName: 0.8.3
     versionCode: 3
-    commit: 4af44ef4ee550680e3eb95848092aab10d18dc01
+    commit: 6b3bf07cc1869cdf93cccd954d16b790a27deed5
     subdir: banana_split_flutter
     sudo:
       - echo "deb https://deb.debian.org/debian bookworm main" > /etc/apt/sources.list.d/bookworm.list
@@ -52,25 +53,24 @@ Builds:
     srclibs:
       - flutter@stable
     prebuild:
+      - sed -i -e '/mobile_scanner/d' pubspec.yaml
+      - mv lib/widgets/shard_scanner.dart.fdroid lib/widgets/shard_scanner.dart
       - flutterVersion=$(sed -n -E "s/.*FLUTTER_VERSION:\ '(.*)'/\1/p" ../.github/workflows/release.yml)
       - '[[ $flutterVersion ]]'
       - git -C $$flutter$$ checkout -f $flutterVersion
       - export PUB_CACHE=$(pwd)/.pub-cache
       - $$flutter$$/bin/flutter config --no-analytics
-      - sed -i '/mobile_scanner:/d' pubspec.yaml
-      - cp lib/widgets/shard_scanner.dart.fdroid lib/widgets/shard_scanner.dart
       - $$flutter$$/bin/flutter pub get
     scandelete:
       - banana_split_flutter/.pub-cache
     build:
-      - export JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64
       - export PUB_CACHE=$(pwd)/.pub-cache
       - $$flutter$$/bin/flutter gen-l10n
       - $$flutter$$/bin/flutter build apk --release
 
-  - versionName: 0.8.5
-    versionCode: 4
-    commit: ee9308a556bc5201364fb5d6dbc48894147bcaf6
+  - versionName: 0.8.6
+    versionCode: 5
+    commit: 2214668e7a55a0c32770abbdf1871ea2757f2947
     subdir: banana_split_flutter
     sudo:
       - echo "deb https://deb.debian.org/debian bookworm main" > /etc/apt/sources.list.d/bookworm.list
@@ -81,18 +81,18 @@ Builds:
     srclibs:
       - flutter@stable
     prebuild:
+      - sed -i -e '/mobile_scanner/d' pubspec.yaml
+      - cp pubspec.lock.fdroid pubspec.lock
+      - mv lib/widgets/shard_scanner.dart.fdroid lib/widgets/shard_scanner.dart
       - flutterVersion=$(sed -n -E "s/.*FLUTTER_VERSION:\ '(.*)'/\1/p" ../.github/workflows/release.yml)
       - '[[ $flutterVersion ]]'
       - git -C $$flutter$$ checkout -f $flutterVersion
       - export PUB_CACHE=$(pwd)/.pub-cache
       - $$flutter$$/bin/flutter config --no-analytics
-      - sed -i '/mobile_scanner:/d' pubspec.yaml
-      - cp lib/widgets/shard_scanner.dart.fdroid lib/widgets/shard_scanner.dart
-      - $$flutter$$/bin/flutter pub get
+      - $$flutter$$/bin/flutter pub get --enforce-lockfile
     scandelete:
       - banana_split_flutter/.pub-cache
     build:
-      - export JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64
       - export PUB_CACHE=$(pwd)/.pub-cache
       - $$flutter$$/bin/flutter gen-l10n
       - $$flutter$$/bin/flutter build apk --release
@@ -100,5 +100,5 @@ Builds:
 AutoUpdateMode: Version
 UpdateCheckMode: Tags
 UpdateCheckData: banana_split_flutter/pubspec.yaml|version:\s.+\+(\d+)|.|version:\s(.+)\+
-CurrentVersion: 0.8.5
-CurrentVersionCode: 4
+CurrentVersion: 0.8.6
+CurrentVersionCode: 5


### PR DESCRIPTION
Adds the versionCode 5 build entry pinned to `2214668` (the `v0.8.6` tag) and moves `CurrentVersion`/`CurrentVersionCode` to `0.8.6`/`5`.

## The new entry adopts `--enforce-lockfile`

```yaml
      - sed -i -e '/mobile_scanner/d' pubspec.yaml
      - cp pubspec.lock.fdroid pubspec.lock          # new
      - mv lib/widgets/shard_scanner.dart.fdroid lib/widgets/shard_scanner.dart
      ...
      - $$flutter$$/bin/flutter pub get --enforce-lockfile   # was: pub get
```

Ordering is load-bearing: the `sed` must strip `mobile_scanner` **before** the FOSS lock is copied in, because that lock describes the stripped pubspec.

The 0.8.2 and 0.8.3 entries deliberately keep their original recipes — they must still build as published.

## Also reconciles this file with canonical fdroiddata

It had drifted, and anything reasoning from it was reasoning about a recipe F-Droid does not run:

| | was (local) | now (canonical) |
|---|---|---|
| 0.8.3 commit | `4af44ef4…` | `6b3bf07c…` |
| 0.8.2 FOSS swap | absent | present |
| scanner swap verb | `cp` | `mv` |
| `JAVA_HOME` export in build | present | absent |

## versionCode 4 (0.8.5) is skipped deliberately

`pubspec.lock.fdroid` did not exist at that tag, so no entry pinned there could use the enforced lockfile. F-Droid users move 0.8.3 → 0.8.6 and get the Spanish translation in that jump.

## Verified against the pinned commit

```
OK  banana_split_flutter/pubspec.lock.fdroid
OK  banana_split_flutter/lib/widgets/shard_scanner.dart.fdroid
OK  .github/workflows/release.yml
OK  banana_split_flutter/pubspec.yaml
FLUTTER_VERSION extraction -> 3.24.5 (exactly 1 line)
tools/validate_store_metadata.py -> OK
```

Upstream CI (`F-Droid FOSS Lockfile`) exercises this exact prebuild on every Flutter change.

## Next

Submit the fdroiddata MR with this build entry — draft at `scratchpad/fdroid-mr-draft.md`, now complete with the real hash. This repo's copy is a mirror; the canonical file is at `metadata/com.nfcarchiver.banana_split.yml` in `fdroiddata` (fork: `gitlab.com/mezinster/fdroiddata`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)