### PR TITLE
chore: record the 0.9.0 F-Droid build entry

### DIFF
--- a/fdroid/com.nfcarchiver.banana_split.yml
+++ b/fdroid/com.nfcarchiver.banana_split.yml
@@ -97,8 +97,38 @@ Builds:
       - $$flutter$$/bin/flutter gen-l10n
       - $$flutter$$/bin/flutter build apk --release
 
+  - versionName: 0.9.0
+    versionCode: 6
+    commit: 9eae0aec4af4331c4118d30c36eae13935ff4a76
+    subdir: banana_split_flutter
+    sudo:
+      - echo "deb https://deb.debian.org/debian bookworm main" > /etc/apt/sources.list.d/bookworm.list
+      - apt-get update
+      - apt-get install -y -t bookworm openjdk-17-jdk-headless
+      - update-java-alternatives -s java-1.17.0-openjdk-amd64
+    output: build/app/outputs/flutter-apk/app-release.apk
+    srclibs:
+      - flutter@stable
+    prebuild:
+      - sed -i -e '/mobile_scanner/d' pubspec.yaml
+      - cp pubspec.lock.fdroid pubspec.lock
+      - mv lib/widgets/shard_scanner.dart.fdroid lib/widgets/shard_scanner.dart
+      - flutterVersion=$(sed -n -E "s/.*FLUTTER_VERSION:\ '(.*)'/\1/p" ../.github/workflows/release.yml)
+      - '[[ $flutterVersion ]]'
+      - git -C $$flutter$$ checkout -f $flutterVersion
+      - export PUB_CACHE=$(pwd)/.pub-cache
+      - $$flutter$$/bin/flutter config --no-analytics
+      - $$flutter$$/bin/flutter pub get --enforce-lockfile
+    scandelete:
+      - banana_split_flutter/.pub-cache
+    build:
+      - export PUB_CACHE=$(pwd)/.pub-cache
+      - $$flutter$$/bin/flutter gen-l10n
+      - $$flutter$$/bin/flutter build apk --release
+
+
 AutoUpdateMode: Version
 UpdateCheckMode: Tags
 UpdateCheckData: banana_split_flutter/pubspec.yaml|version:\s.+\+(\d+)|.|version:\s(.+)\+
-CurrentVersion: 0.8.6
-CurrentVersionCode: 5
+CurrentVersion: 0.9.0
+CurrentVersionCode: 6


### PR DESCRIPTION
Adds the versionCode 6 build entry pinned to `9eae0ae` (the `v0.9.0` tag) and moves `CurrentVersion`/`CurrentVersionCode` to `0.9.0`/`6`.

### The recipe is unchanged

Same prebuild as 0.8.6 — same `cp pubspec.lock.fdroid pubspec.lock`, same `pub get --enforce-lockfile`.

**The Flutter 3.44.8 upgrade rides along implicitly.** The recipe greps `FLUTTER_VERSION` out of `release.yml`, which now reads `3.44.8`, so the F-Droid build picks up the new SDK with no recipe edit. That is also why the FOSS lockfile was regenerated in #15 — F-Droid resolves against the same new SDK.

### Verified at the pinned commit

```
3.44.8  (FLUTTER_VERSION extraction — exactly 1 line)
OK  banana_split_flutter/pubspec.lock.fdroid
OK  banana_split_flutter/lib/widgets/shard_scanner.dart.fdroid
OK  .github/workflows/release.yml
OK  banana_split_flutter/pubspec.yaml
tools/validate_store_metadata.py -> OK
```

### No fdroiddata MR needed

Only the version changes, not the recipe, so the `checkupdates` bot produces this entry itself — as it did for 0.8.3. Recorded here so the local copy stays an accurate mirror rather than drifting again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)