### PR TITLE
fix: unpin the Windows runners by suppressing the coroutine deprecation

### DIFF
--- a/.github/workflows/flutter-ci.yml
+++ b/.github/workflows/flutter-ci.yml
@@ -207,9 +207,8 @@ jobs:
     name: Build Windows
     needs: analyze-and-test
     if: github.event_name == 'workflow_dispatch' && inputs.build_windows
-    # Still pinned — blocked by permission_handler_windows, not by Flutter.
-    # See the note in release.yml's build-windows job.
-    runs-on: windows-2022
+    # Unpinned — see the note in release.yml's build-windows job.
+    runs-on: windows-latest
     defaults:
       run:
         working-directory: banana_split_flutter

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -246,23 +246,18 @@ jobs:
   build-windows:
     name: Build Windows
     needs: [version, test]
-    # Still pinned, but for a different reason than before.
+    # Unpinned. Two separate problems had to be cleared to get here:
+    #   1. Flutter 3.24.5 could not locate Visual Studio on this image and fell
+    #      back to the VS 2019 CMake generator — fixed by the 3.44.8 upgrade.
+    #   2. MSVC 14.51 hard-errors on <experimental/coroutine>, which
+    #      permission_handler_windows drags in via its legacy /await flag —
+    #      suppressed in banana_split_flutter/windows/CMakeLists.txt, see the
+    #      comment there and Baseflow/flutter-permission-handler#1534.
     #
-    # Originally: Flutter 3.24.5 could not locate Visual Studio on the current
-    # windows-latest image and fell back to the VS 2019 CMake generator. The
-    # 3.44.8 bump fixed that — VS is now found correctly.
-    #
-    # Now: windows-latest ships VS 18 / MSVC 14.51, whose STL hard-errors on
-    # <experimental/coroutine> (STL1011). permission_handler_windows passes the
-    # legacy `/await` flag in its own CMakeLists, so it cannot compile there:
-    #   error C2338: static assertion failed: 'error STL1011: ... /await ...'
-    # This is upstream, not ours, and 0.2.2 (2026-07-31, latest) still does it.
-    #
-    # Unpin once permission_handler_windows drops `/await` for C++20
-    # <coroutine>. Verify with a `flutter-ci` workflow_dispatch on a branch
-    # (build_windows=true) — PR CI never runs this job, so a green PR says
-    # nothing about it.
-    runs-on: windows-2022
+    # PR CI never runs this job, so a green PR proves nothing about it. Verify
+    # any change here with a `flutter-ci` workflow_dispatch (build_windows=true)
+    # on a branch before merging.
+    runs-on: windows-latest
     defaults:
       run:
         working-directory: banana_split_flutter

--- a/banana_split_flutter/windows/CMakeLists.txt
+++ b/banana_split_flutter/windows/CMakeLists.txt
@@ -53,6 +53,28 @@ add_subdirectory(${FLUTTER_MANAGED_DIR})
 add_subdirectory("runner")
 
 
+# Workaround for Baseflow/flutter-permission-handler#1534.
+#
+# permission_handler_windows passes the legacy /await flag in its own
+# windows/CMakeLists.txt even though it already requests cxx_std_20. That drags
+# in <experimental/coroutine>, which the MSVC 14.51 STL shipped with VS 18
+# hard-errors on (STL1011), so the plugin cannot compile on the current
+# windows-latest runner image.
+#
+# The upstream fix is to delete that one line — reported 2026-05-21, root cause
+# identified 2026-05-24, still unreleased as of permission_handler_windows
+# 0.2.2 (2026-07-31). Until then this suppression lets the plugin build.
+#
+# Must precede generated_plugins.cmake: the plugin targets are created there.
+#
+# This is deliberately temporary. It silences a deprecation whose own text says
+# the headers "will be REMOVED SOON" — when MSVC actually removes them the
+# suppression stops working and the plugin breaks for everyone, which is what
+# will force the upstream fix. Drop this block once the plugin no longer passes
+# /await; verify with a `flutter-ci` workflow_dispatch (build_windows=true),
+# because PR CI never runs the Windows job.
+add_compile_definitions(_SILENCE_EXPERIMENTAL_COROUTINE_DEPRECATION_WARNINGS)
+
 # Generated plugin build rules, which manage building the plugins and adding
 # them to the application.
 include(flutter/generated_plugins.cmake)


### PR DESCRIPTION
Both runners go back to `windows-latest`. This finally delivers what #12 set out to do — the SDK bump alone could not.

## Two separate problems, only one of which was Flutter's

1. Flutter 3.24.5 could not locate Visual Studio on this image and fell back to the VS 2019 CMake generator. **Fixed by the 3.44.8 upgrade** (#15).
2. MSVC 14.51 (VS 18) hard-errors on `<experimental/coroutine>`, which `permission_handler_windows` drags in by passing the legacy `/await` flag despite already requesting `cxx_std_20`.

The second is [Baseflow/flutter-permission-handler#1534](https://github.com/Baseflow/flutter-permission-handler/issues/1534) — reported 2026-05-21, root cause identified in the thread 2026-05-24 (delete the one `/await` line), still unreleased as of `permission_handler_windows` 0.2.2 on 2026-07-31.

**Nothing to file upstream.** I went to draft an issue and found it already reported, with the fix. A new issue would be a duplicate.

## The workaround, and why this one is acceptable

I had advised against working around it locally — but I was picturing a plugin fork. The thread's suggestion is one line in a file we already own:

```cmake
add_compile_definitions(_SILENCE_EXPERIMENTAL_COROUTINE_DEPRECATION_WARNINGS)
```

Placed before `generated_plugins.cmake`, which is where the plugin targets are created. No fork, no `dependency_overrides`, reversible, and inert once upstream lands the fix.

**Deliberately temporary, and the comment says so.** It silences a deprecation whose own text says the headers "will be REMOVED SOON". When MSVC removes them the suppression stops working and the plugin breaks for everyone — which is what will force the upstream fix. Both the pin and this workaround have an expiry; the difference is that this one's expiry is upstream's problem, not ours.

## Verified where it counts

`Build Windows` is `workflow_dispatch`-only, so **PR CI proves nothing about this change** — the same blind spot that let v0.8.5 fail and that made #15 look green while its stated purpose was broken. Validated by dispatching `flutter-ci` on this branch with `build_windows=true`:

```
Build Windows          success   ← windows-latest, MSVC 14.51
Analyze & Test         success
F-Droid FOSS Lockfile  success
Validate Store Metadata success
```

Both `runs-on` comments now record that a dispatch is the only way to verify this job.

## Scope of the evidence

This proves the plugin **compiles** and the Windows build succeeds. It does not exercise the binary at runtime — though the suppression changes no generated code, and `permission_handler` is never called on Windows anyway (guarded to Android/macOS at `shard_scanner.dart:279`).

No release needed; this only affects CI configuration and the Windows build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)